### PR TITLE
Remove isRunning assignment

### DIFF
--- a/rolling-restart.go
+++ b/rolling-restart.go
@@ -113,7 +113,6 @@ func (c *RollingRestart) Run(conn plugin.CliConnection, args []string) {
 
 		printFormatted("Checking status of instance %s.\n", instanceID)
 
-		isRunning = false
 		for i := 0; i < maxRestartWaitCycles; i++ {
 			spinner.Next()
 


### PR DESCRIPTION
### What was a problem?

Missed ineffectual assignment in the rolling_restart code. 

### How this PR fixes the problem?

It removes the extra assignment that never gets used. 

### Check lists (check `x` in `[ ]` of list items)

- [X] Test passed
- [X] Coding style (indentation, etc)

### Additional Comments (if any)

N/A