### PR TITLE
Update Travis to only build master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,7 @@ script:
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+  
+branches:
+  only:
+  - master


### PR DESCRIPTION
### What was a problem?

Travis will build all branches with toggle on, no branches including master if off. We want master and PR. 

### How this PR fixes the problem?

Limits branch building to master. 

### Check lists (check `x` in `[ ]` of list items)

- [ ] Test passed
- [X] Coding style (indentation, etc)

### Additional Comments (if any)

Tests unknown, changed in github ui. 