### PR TITLE
Restart single app instance

### DIFF
--- a/rolling-restart.go
+++ b/rolling-restart.go
@@ -162,7 +162,7 @@ func execute(conn plugin.CliConnection, args []string) (exitCode int) {
 	return successfulExit
 }
 
-func scaleApplication(conn plugin.CliConnection, appName string, numberOfInstances int) (error) {
+func scaleApplication(conn plugin.CliConnection, appName string, numberOfInstances int) error {
 	_, err := conn.CliCommand("scale", appName, "-i", strconv.Itoa(numberOfInstances))
 	return err
 }

--- a/rolling-restart_test.go
+++ b/rolling-restart_test.go
@@ -357,7 +357,7 @@ func setupCliCommandStub(restartSuccess bool, scaleSuccess bool) {
 	cliConn.CliCommandStub = func(args ...string) ([]string, error) {
 		if args[0] == "restart-app-instance" && args[1] == "testApp" && (args[2] == "0" || args[2] == "1") && restartSuccess {
 			return nil, nil
-		} else if args[0] == "scale" && args[1] == "testApp" && args[2] == "-i" && args[3] == "2" && scaleSuccess{
+		} else if args[0] == "scale" && args[1] == "testApp" && args[2] == "-i" && args[3] == "2" && scaleSuccess {
 			return nil, nil
 		}
 		return nil, &testError{1, "CliCommandStubError"}

--- a/rolling-restart_test.go
+++ b/rolling-restart_test.go
@@ -75,11 +75,12 @@ func TestMain(m *testing.M) {
 }
 
 func TestRollingRestart_Run_Success(t *testing.T) {
+	resetOutput()
 	setupIsLoggedInStub(true, false)
 	setupHasOrganizationStub(true, false)
 	setupHasSpaceStub(true, false)
 	setupCliCommandWihtoutTerminalOutputStub(true, true, twoInstanceResponse)
-	setupCliCommandStub(true)
+	setupCliCommandStub(true, true)
 
 	rr.Run(cliConn, []string{"rolling-restart", "testApp"})
 
@@ -101,72 +102,105 @@ func TestRollingRestart_Run_Success(t *testing.T) {
 	require.Contains(t, spinnerBuffer.String(), "OK")
 
 	require.Equal(t, exitCode, 0)
+}
+
+func TestRollingRestart_Run_Success_SingleAppInstance(t *testing.T) {
 	resetOutput()
+	setupIsLoggedInStub(true, false)
+	setupHasOrganizationStub(true, false)
+	setupHasSpaceStub(true, false)
+	setupCliCommandWihtoutTerminalOutputStub(true, true, singleInstanceResponse)
+	setupCliCommandStub(true, true)
+
+	rr.Run(cliConn, []string{"rolling-restart", "testApp"})
+
+	require.Equal(t, 3, cliConn.CliCommandCallCount())
+	require.Equal(t, []string{"scale", "testApp", "-i", "2"}, cliConn.CliCommandArgsForCall(0))
+	require.Equal(t, []string{"restart-app-instance", "testApp", "0"}, cliConn.CliCommandArgsForCall(1))
+	require.Equal(t, []string{"scale", "testApp", "-i", "1"}, cliConn.CliCommandArgsForCall(2))
+
+	require.Equal(t, 4, cliConn.CliCommandWithoutTerminalOutputCallCount())
+	require.Equal(t, []string{"app", "testApp", "--guid"}, cliConn.CliCommandWithoutTerminalOutputArgsForCall(0))
+	require.Equal(t, []string{"curl", "-X", "GET", "/v2/apps/valid-app-guid/instances"}, cliConn.CliCommandWithoutTerminalOutputArgsForCall(1))
+	require.Equal(t, []string{"curl", "-X", "GET", "/v2/apps/valid-app-guid/instances"}, cliConn.CliCommandWithoutTerminalOutputArgsForCall(2))
+
+	require.Equal(t, 6, len(output))
+	require.Equal(t, "Scaling testApp to two instances.", output[0])
+	require.Equal(t, "Beginning restart of app instances for testApp.\n", output[1])
+	require.Equal(t, "Checking status of instance 0.\n", output[2])
+	require.Equal(t, "Checking status of instance 1.\n", output[3])
+	require.Equal(t, "Finished restart of app instances for testApp.", output[4])
+	require.Equal(t, "Scaling testApp to one instance.", output[5])
+
+	require.Contains(t, spinnerBuffer.String(), "OK")
+
+	require.Equal(t, exitCode, 0)
 }
 
 func TestRollingRestart_Run_NoAppNameProvided(t *testing.T) {
+	resetOutput()
 	rr.Run(cliConn, []string{"rolling-restart"})
 
 	require.Equal(t, exitCode, 1)
 	require.Equal(t, "An application name was not provided. Usage: cf rolling-restart APP_NAME\n", output[0])
-	resetOutput()
 }
 
 func TestRollingRestart_Run_MultipleAppNameProvided(t *testing.T) {
+	resetOutput()
 	rr.Run(cliConn, []string{"rolling-restart", "firstApp", "secondApp"})
 
 	require.Equal(t, exitCode, 1)
 	require.Equal(t, "Only a single app name is currently supported, please try again.\n", output[0])
-	resetOutput()
 }
 
 func TestRollingRestart_Run_ArguementParsingError(t *testing.T) {
+	resetOutput()
 	rr.Run(cliConn, []string{"rolling-restart", "firstApp", "secondApp"})
 
 	require.Equal(t, exitCode, 1)
 	require.Equal(t, "Only a single app name is currently supported, please try again.\n", output[0])
-	resetOutput()
 }
 
 func TestRollingRestart_Run_NotLoggedIn(t *testing.T) {
+	resetOutput()
 	setupIsLoggedInStub(false, false)
 	rr.Run(cliConn, []string{"rolling-restart", "testApp"})
 
 	require.Equal(t, exitCode, 1)
 	require.Equal(t, "You are not logged in, please log in and try again.\n", output[0])
-	resetOutput()
 }
 
 func TestRollingRestart_Run_isLoggedInThrowsErr(t *testing.T) {
+	resetOutput()
 	setupIsLoggedInStub(false, true)
 	rr.Run(cliConn, []string{"rolling-restart", "testApp"})
 
 	require.Equal(t, exitCode, 1)
 	require.Contains(t, output[0], "CLI FAILURE")
-	resetOutput()
 }
 
 func TestRollingRestart_Run_OrgNotSet(t *testing.T) {
+	resetOutput()
 	setupIsLoggedInStub(true, false)
 	setupHasOrganizationStub(false, false)
 	rr.Run(cliConn, []string{"rolling-restart", "testApp"})
 
 	require.Equal(t, exitCode, 1)
 	require.Contains(t, output[0], "The logged in user does not have an Org set, please select an Org and Space and try again.")
-	resetOutput()
 }
 
 func TestRollingRestart_Run_hasOrgThrowsErr(t *testing.T) {
+	resetOutput()
 	setupIsLoggedInStub(true, false)
 	setupHasOrganizationStub(false, true)
 	rr.Run(cliConn, []string{"rolling-restart", "testApp"})
 
 	require.Equal(t, exitCode, 1)
 	require.Contains(t, output[0], "CLI FAILURE")
-	resetOutput()
 }
 
 func TestRollingRestart_Run_SpaceNotSet(t *testing.T) {
+	resetOutput()
 	setupIsLoggedInStub(true, false)
 	setupHasOrganizationStub(true, false)
 	setupHasSpaceStub(false, false)
@@ -174,10 +208,10 @@ func TestRollingRestart_Run_SpaceNotSet(t *testing.T) {
 
 	require.Equal(t, exitCode, 1)
 	require.Contains(t, output[0], "The logged in user does not have a Space set, please select a Space and try again.")
-	resetOutput()
 }
 
 func TestRollingRestart_Run_hasSpaceThrowsError(t *testing.T) {
+	resetOutput()
 	setupIsLoggedInStub(true, false)
 	setupHasOrganizationStub(true, false)
 	setupHasSpaceStub(false, true)
@@ -185,10 +219,10 @@ func TestRollingRestart_Run_hasSpaceThrowsError(t *testing.T) {
 
 	require.Equal(t, exitCode, 1)
 	require.Contains(t, output[0], "CLI FAILURE")
-	resetOutput()
 }
 
 func TestRollingRestart_Run_GetGuidThrowsError(t *testing.T) {
+	resetOutput()
 	setupIsLoggedInStub(true, false)
 	setupHasOrganizationStub(true, false)
 	setupHasSpaceStub(false, true)
@@ -197,10 +231,10 @@ func TestRollingRestart_Run_GetGuidThrowsError(t *testing.T) {
 
 	require.Equal(t, exitCode, 1)
 	require.Contains(t, output[0], "CLI FAILURE")
-	resetOutput()
 }
 
 func TestRollingRestart_Run_GetInstancesThrowsError(t *testing.T) {
+	resetOutput()
 	setupIsLoggedInStub(true, false)
 	setupHasOrganizationStub(true, false)
 	setupHasSpaceStub(false, true)
@@ -209,23 +243,23 @@ func TestRollingRestart_Run_GetInstancesThrowsError(t *testing.T) {
 
 	require.Equal(t, exitCode, 1)
 	require.Contains(t, output[0], "CLI FAILURE")
-	resetOutput()
 }
 
 func TestRollingRestart_Run_RestartInstanceThrowsError(t *testing.T) {
+	resetOutput()
 	setupIsLoggedInStub(true, false)
 	setupHasOrganizationStub(true, false)
 	setupHasSpaceStub(false, true)
 	setupCliCommandWihtoutTerminalOutputStub(true, true, twoInstanceResponse)
-	setupCliCommandStub(false)
+	setupCliCommandStub(false, true)
 	rr.Run(cliConn, []string{"rolling-restart", "testApp"})
 
 	require.Equal(t, exitCode, 1)
 	require.Contains(t, output[0], "CLI FAILURE")
-	resetOutput()
 }
 
 func TestRollingRestart_Run_InstanceJsonUnmarshallError(t *testing.T) {
+	resetOutput()
 	setupIsLoggedInStub(true, false)
 	setupHasOrganizationStub(true, false)
 	setupHasSpaceStub(false, true)
@@ -234,50 +268,49 @@ func TestRollingRestart_Run_InstanceJsonUnmarshallError(t *testing.T) {
 
 	require.Equal(t, exitCode, 1)
 	require.Contains(t, output[0], "CLI FAILURE")
-	resetOutput()
 }
 
 func TestRollingRestart_Run_InstanceDoesNotRestartInCycleLimit(t *testing.T) {
+	resetOutput()
 	setupIsLoggedInStub(true, false)
 	setupHasOrganizationStub(true, false)
 	setupHasSpaceStub(true, false)
 	setupCliCommandWihtoutTerminalOutputStub(true, true, alwaysRestartingResponse)
-	setupCliCommandStub(true)
+	setupCliCommandStub(true, true)
 	rr.Run(cliConn, []string{"rolling-restart", "testApp"})
 
 	require.Equal(t, exitCode, 1)
 	require.Contains(t, output[0], "Beginning restart of app instances for testApp.")
 	require.Contains(t, output[1], "Checking status of instance 0.")
 	require.Contains(t, output[2], "Application did not restart within 1 Second(s), failing out. Check your current application state.")
-	resetOutput()
 }
 
 func TestRollingRestart_Run_InstanceDoesNotRestartCustomCycleLimit(t *testing.T) {
+	resetOutput()
 	setupIsLoggedInStub(true, false)
 	setupHasOrganizationStub(true, false)
 	setupHasSpaceStub(true, false)
 	setupCliCommandWihtoutTerminalOutputStub(true, true, alwaysRestartingResponse)
-	setupCliCommandStub(true)
+	setupCliCommandStub(true, true)
 	rr.Run(cliConn, []string{"rolling-restart", "--max-cycles", "2", "testApp"})
 
 	require.Equal(t, exitCode, 1)
 	require.Contains(t, output[0], "Beginning restart of app instances for testApp.")
 	require.Contains(t, output[1], "Checking status of instance 0.")
 	require.Contains(t, output[2], "Application did not restart within 2 Second(s), failing out. Check your current application state.")
-	resetOutput()
 }
 
 func TestRollingRestart_Run_SingleInstanceThrowError(t *testing.T) {
+	resetOutput()
 	setupIsLoggedInStub(true, false)
 	setupHasOrganizationStub(true, false)
 	setupHasSpaceStub(true, false)
 	setupCliCommandWihtoutTerminalOutputStub(true, true, singleInstanceResponse)
-	setupCliCommandStub(true)
+	setupCliCommandStub(true, true)
 	rr.Run(cliConn, []string{"rolling-restart", "testApp"})
 
 	require.Equal(t, exitCode, 1)
 	require.Contains(t, output[0], "There are too few instances to ensure zero-downtime, use `cf restart APP_NAME` if you are OK with downtime.")
-	resetOutput()
 }
 
 func setupHasSpaceStub(hasSpace bool, throwError bool) {
@@ -318,9 +351,11 @@ func setupCliCommandWihtoutTerminalOutputStub(getGUIDSuccess bool, getInstanceSt
 	}
 }
 
-func setupCliCommandStub(restartSuccess bool) {
+func setupCliCommandStub(restartSuccess bool, scaleSuccess bool) {
 	cliConn.CliCommandStub = func(args ...string) ([]string, error) {
 		if args[0] == "restart-app-instance" && args[1] == "testApp" && (args[2] == "0" || args[2] == "1") && restartSuccess {
+			return nil, nil
+		} else if args[0] == "scale" && args[1] == "testApp" && args[2] == "-i" && args[3] == "2" && scaleSuccess{
 			return nil, nil
 		}
 		return nil, &testError{}


### PR DESCRIPTION
### What was a problem?

As described in issue #7, the plugin was unable to restart a single instance of an application due to the fact that it would take that application down. 

### How this PR fixes the problem?

This PR introduces the ability to scale the application up prior to restarting the single app instance so that there is an instance available to serve requests during the restart of the existing instance. 

### Check lists (check `x` in `[ ]` of list items)

- [X] Test passed
- [X] Coding style (indentation, etc)

### Additional Comments (if any)

N/A